### PR TITLE
DefaultOMEMetadataService: get BigEndian from image index only

### DIFF
--- a/src/main/java/io/scif/ome/services/DefaultOMEMetadataService.java
+++ b/src/main/java/io/scif/ome/services/DefaultOMEMetadataService.java
@@ -571,7 +571,8 @@ public class DefaultOMEMetadataService extends AbstractService implements
 			retrieve.getChannelCount(imageIndex) <= 0 ? null : retrieve
 				.getChannelSamplesPerPixel(imageIndex, 0);
 
-		final boolean little = !retrieve.getPixelsBinDataBigEndian(imageIndex, 0);
+		
+		final boolean little = !retrieve.getPixelsBigEndian(imageIndex);
 		final int pType =
 			FormatTools.pixelTypeFromString(retrieve.getPixelsType(imageIndex)
 				.getValue());


### PR DESCRIPTION
I experienced an `IndexOutOfBoundsException` when running the following code:

```
public static void main(String[] args) {
		Context ctx = new Context();
		try {
			FormatService service = ctx.getService(FormatService.class);
			for (Format f : service.getAllFormats()) {
				System.out.println(Arrays.toString(f.getSuffixes()));
			}
			final Format format = ctx.getService(FormatService.class).getFormat("/home/dietzc/Downloads/example.czi",
					new SCIFIOConfig().checkerSetOpen(true));
			
			Reader reader = format.createReader();
			final Parser p = format.createParser();

			reader.setMetadata(p.parse("/home/dietzc/Downloads/example.czi"));

			final Metadata meta = reader.getMetadata();

			final OMEMetadata omexml = new OMEMetadata(ctx);

			ctx.getService(TranslatorService.class).translate(meta, omexml, false);

			final String xml = omexml.getRoot().dumpXML();

			System.out.println(xml);
		} catch (Exception e) {
			// TODO Auto-generated catch block
			e.printStackTrace();
		}
	}
```

The proposed fix doesn't rely on the existence of a bin anymore, rather uses only the `imageindex` to get the information about the `BigEndian`. I've no idea why the other method with `index,binIdx` was called before, maybe @hinerm can comment on this? 

Also I don't know if this fix has side-effects, I can just say that the `IndexOutOfBoundsException` is resolved with this PR. @ctrueden what do you think?